### PR TITLE
Add initial WebSocket transport

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "sipua"
 version = "0.1.0"
 
 # Dependencies
-dependencies = ["sipmessage"]
+dependencies = ["sipmessage", "websockets"]
 requires-python = ">= 3.10"
 
 # Development

--- a/src/sipua/utils.py
+++ b/src/sipua/utils.py
@@ -1,3 +1,8 @@
+#
+# Copyright (C) Spacinov SAS
+# Distributed under the 2-clause BSD license
+#
+
 import secrets
 import string
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,8 @@
+#
+# Copyright (C) Spacinov SAS
+# Distributed under the 2-clause BSD license
+#
+
 import asyncio
 import functools
 from collections.abc import Callable, Coroutine


### PR DESCRIPTION
The WebSocket transport can only handle incoming connections, and cannot establish outgoing connections.