### PR TITLE
Adapt code to parse SIP messages from bytes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,10 @@ name = "sipua"
 version = "0.3.0"
 
 # Dependencies
-dependencies = ["sipmessage", "websockets"]
+dependencies = [
+    "sipmessage >= 0.6.0, < 0.7.0",
+    "websockets",
+]
 requires-python = ">= 3.10"
 
 # Development

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,11 +8,13 @@ from .utils import lf2crlf, parse_request
 
 
 class UtilsTest(unittest.TestCase):
-    def assertMessage(self, message: sipmessage.Message, data: str) -> None:
-        self.assertEqual(str(message), lf2crlf(data))
+    def assertMessage(
+        self, message: sipmessage.Request | sipmessage.Response, data: bytes
+    ) -> None:
+        self.assertEqual(bytes(message), lf2crlf(data))
 
     def test_create_invite_response_and_ack(self) -> None:
-        request = parse_request("""INVITE sip:+33233445566@127.0.0.1:5060 SIP/2.0
+        request = parse_request(b"""INVITE sip:+33233445566@127.0.0.1:5060 SIP/2.0
 Via: SIP/2.0/UDP 127.0.0.1:43248;branch=z9hG4bK1e5b2b763d
 Max-Forwards: 70
 To: sip:+33233445566@127.0.0.1:5060
@@ -38,7 +40,7 @@ a=silenceSupp:off - - - -
         response = create_response(request=request, code=200)
         self.assertMessage(
             response,
-            """SIP/2.0 200 OK
+            b"""SIP/2.0 200 OK
 Via: SIP/2.0/UDP 127.0.0.1:43248;branch=z9hG4bK1e5b2b763d
 To: <sip:+33233445566@127.0.0.1:5060>
 From: <sip:+33122334455@127.0.0.1:43248>;tag=7bc759c98ae3e112
@@ -51,7 +53,7 @@ CSeq: 1 INVITE
         ack = create_ack(request=request, response=response)
         self.assertMessage(
             ack,
-            """ACK sip:+33233445566@127.0.0.1:5060 SIP/2.0
+            b"""ACK sip:+33233445566@127.0.0.1:5060 SIP/2.0
 Via: SIP/2.0/UDP 127.0.0.1:43248;branch=z9hG4bK1e5b2b763d
 To: <sip:+33233445566@127.0.0.1:5060>
 From: <sip:+33122334455@127.0.0.1:43248>;tag=7bc759c98ae3e112
@@ -62,7 +64,7 @@ CSeq: 1 ACK
         )
 
     def test_create_invite_response_with_record_route(self) -> None:
-        request = parse_request("""INVITE sip:callee@u2.domain.com SIP/2.0
+        request = parse_request(b"""INVITE sip:callee@u2.domain.com SIP/2.0
 Via: SIP/2.0/UDP 127.0.0.1:43248;branch=z9hG4bK1e5b2b763d
 Max-Forwards: 70
 To: sip:callee@127.0.0.1:5060
@@ -90,7 +92,7 @@ a=silenceSupp:off - - - -
         response = create_response(request=request, code=200)
         self.assertMessage(
             response,
-            """SIP/2.0 200 OK
+            b"""SIP/2.0 200 OK
 Via: SIP/2.0/UDP 127.0.0.1:43248;branch=z9hG4bK1e5b2b763d
 To: <sip:callee@127.0.0.1:5060>
 From: <sip:+caller@127.0.0.1:43248>;tag=7bc759c98ae3e112

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -24,17 +24,17 @@ def asynctest(
     return wrap
 
 
-def lf2crlf(x: str) -> str:
-    return x.replace("\n", "\r\n")
+def lf2crlf(x: bytes) -> bytes:
+    return x.replace(b"\n", b"\r\n")
 
 
-def parse_request(data: str) -> sipmessage.Request:
+def parse_request(data: bytes) -> sipmessage.Request:
     message = sipmessage.Message.parse(lf2crlf(data))
     assert isinstance(message, sipmessage.Request)
     return message
 
 
-def parse_response(data: str) -> sipmessage.Response:
+def parse_response(data: bytes) -> sipmessage.Response:
     message = sipmessage.Message.parse(lf2crlf(data))
     assert isinstance(message, sipmessage.Response)
     return message


### PR DESCRIPTION
The `sipmessage` API now parses messages from bytes and serialises them to bytes.