### PR TITLE
Simplify TransactionLayer API

### DIFF
--- a/docs/transaction.rst
+++ b/docs/transaction.rst
@@ -3,11 +3,3 @@ Transaction layer
 
 .. autoclass:: sipua.TransactionLayer
    :members:
-
-.. autoclass:: sipua.ServerInviteTransaction()
-   :members:
-   :inherited-members:
-
-.. autoclass:: sipua.ServerNonInviteTransaction()
-   :members:
-   :inherited-members:

--- a/examples/sip-server.py
+++ b/examples/sip-server.py
@@ -12,9 +12,7 @@ import sipua
 
 
 class SipServer(sipua.Application):
-    async def handle_request(
-        self, request: sipmessage.Request, transaction: sipua.ServerTransaction
-    ) -> None:
+    async def handle_request(self, request: sipmessage.Request) -> None:
         """
         Handle a request outside a dialog.
         """
@@ -24,10 +22,10 @@ class SipServer(sipua.Application):
                 dialog_layer=self.dialog_layer,
                 request=request,
             )
-            await call.accept(transaction)
+            await call.accept(request)
         else:
             # Reject any other requests.
-            await super().handle_request(request, transaction)
+            await super().handle_request(request)
 
 
 async def main() -> None:

--- a/src/sipua/__init__.py
+++ b/src/sipua/__init__.py
@@ -8,12 +8,7 @@ import importlib.metadata
 from .application import Application
 from .call import Call
 from .dialog import Dialog, DialogLayer
-from .transaction import (
-    ServerInviteTransaction,
-    ServerNonInviteTransaction,
-    ServerTransaction,
-    TransactionLayer,
-)
+from .transaction import TransactionLayer
 from .transport import TransportAddress, TransportLayer
 from .utils import create_ack, create_response
 
@@ -24,9 +19,6 @@ __all__ = [
     "Call",
     "Dialog",
     "DialogLayer",
-    "ServerInviteTransaction",
-    "ServerNonInviteTransaction",
-    "ServerTransaction",
     "TransactionLayer",
     "TransportAddress",
     "TransportLayer",

--- a/src/sipua/application.py
+++ b/src/sipua/application.py
@@ -6,7 +6,7 @@
 import sipmessage
 
 from .dialog import DialogLayer
-from .transaction import ServerTransaction, TransactionLayer
+from .transaction import TransactionLayer
 from .transport import TransportAddress, TransportLayer
 from .utils import create_response
 
@@ -42,11 +42,7 @@ class Application:
 
     # overrideable
 
-    async def handle_request(
-        self,
-        request: sipmessage.Request,
-        transaction: ServerTransaction,
-    ) -> None:
+    async def handle_request(self, request: sipmessage.Request) -> None:
         """
         Handle a request which does not match an existing dialog.
 
@@ -54,4 +50,4 @@ class Application:
         for instance to handle incoming calls.
         """
         response = create_response(request=request, code=501)
-        await transaction.send_response(response)
+        await self.transaction_layer.send_response(response)

--- a/tests/test_call.py
+++ b/tests/test_call.py
@@ -61,9 +61,7 @@ class ServerApplication(sipua.Application):
         self.dtls = dtls
         self.ice = ice
 
-    async def handle_request(
-        self, request: sipmessage.Request, transaction: sipua.ServerTransaction
-    ) -> None:
+    async def handle_request(self, request: sipmessage.Request) -> None:
         """
         Handle a request outside a dialog.
         """
@@ -92,9 +90,9 @@ class ServerApplication(sipua.Application):
                 call._handle_sdp = patched_handle_sdp  # type: ignore
 
             # Send response.
-            await call.accept(transaction)
+            await call.accept(request)
         else:
-            await super().handle_request(request, transaction)
+            await super().handle_request(request)
 
 
 class UdpTest(unittest.TestCase):

--- a/tests/test_dialog.py
+++ b/tests/test_dialog.py
@@ -52,7 +52,6 @@ class DialogTest(unittest.TestCase):
     async def server_request_handler(
         self,
         request: sipmessage.Request,
-        transaction: sipua.ServerTransaction,
         *,
         dialog_layer: sipua.DialogLayer,
         route_set: list[sipmessage.Address] = [],
@@ -68,7 +67,8 @@ class DialogTest(unittest.TestCase):
         self.assertEqual(response.cseq, request.cseq)
         self.assertEqual(response.from_address, request.from_address)
         self.assertEqual(response.via, request.via)
-        await transaction.send_response(response)
+        transaction_layer = dialog_layer._transaction_layer
+        await transaction_layer.send_response(response)
 
         # Check server dialog state.
         self.assertEqual(server_dialog.local_cseq, 1)


### PR DESCRIPTION
Do not expose transactions via the API, and instead expose a `send_response` method.