### PR TITLE
Ensure dialog is unregistered when a call terminates

### DIFF
--- a/src/sipua/dialog.py
+++ b/src/sipua/dialog.py
@@ -64,9 +64,10 @@ class Dialog:
         self.local_cseq = 1
         self.remote_address = remote_address
         self.route_set = route_set
+        self._key = (self.call_id, local_tag)
 
         # Register the dialog.
-        dialog_layer._dialogs[(self.call_id, local_tag)] = self
+        dialog_layer._dialogs[self._key] = self
 
     @classmethod
     def create_uac(
@@ -201,3 +202,6 @@ class DialogLayer:
             await dialog.handle_request(request)
         elif self.request_handler is not None:
             await self.request_handler(request)
+
+    def _dialog_terminated(self, dialog: Dialog) -> None:
+        self._dialogs.pop(dialog._key)

--- a/tests/test_call.py
+++ b/tests/test_call.py
@@ -99,7 +99,12 @@ class ServerApplication(sipua.Application):
             await super().handle_request(request)
 
 
-class UdpTest(unittest.TestCase):
+class BaseTestCase(unittest.TestCase):
+    def assertNoDialogs(self, app: sipua.Application) -> None:
+        self.assertEqual(app.dialog_layer._dialogs, {})
+
+
+class UdpTest(BaseTestCase):
     local_address = sipmessage.Address(
         name="Alice",
         uri=sipmessage.URI(
@@ -130,6 +135,8 @@ class UdpTest(unittest.TestCase):
             local_address=self.local_address,
             remote_address=self.remote_address,
         )
+        self.assertNoDialogs(client)
+        self.assertNoDialogs(server)
 
         await asyncio.gather(client.close(), server.close())
 
@@ -159,6 +166,8 @@ class UdpTest(unittest.TestCase):
             local_address=self.local_address,
             remote_address=self.remote_address,
         )
+        self.assertNoDialogs(client)
+        self.assertNoDialogs(server)
 
         await asyncio.gather(client.close(), server.close())
 
@@ -174,6 +183,8 @@ class UdpTest(unittest.TestCase):
             local_address=self.local_address,
             remote_address=self.remote_address,
         )
+        self.assertNoDialogs(client)
+        self.assertNoDialogs(server)
 
         await asyncio.gather(client.close(), server.close())
 
@@ -194,6 +205,8 @@ class UdpTest(unittest.TestCase):
             local_address=self.local_address,
             remote_address=self.remote_address,
         )
+        self.assertNoDialogs(client)
+        self.assertNoDialogs(server)
 
         await asyncio.gather(client.close(), server.close())
 
@@ -226,6 +239,8 @@ class UdpTest(unittest.TestCase):
             remote_address=self.remote_address,
             stun_server="stun:stun.l.google.com:19302",
         )
+        self.assertNoDialogs(client)
+        self.assertNoDialogs(server)
 
         await asyncio.gather(client.close(), server.close())
 
@@ -242,11 +257,13 @@ class UdpTest(unittest.TestCase):
                 remote_address=self.remote_address,
             )
         self.assertEqual(str(cm.exception), "Call failed: 501 Not Implemented")
+        self.assertNoDialogs(client)
+        self.assertNoDialogs(server)
 
         await asyncio.gather(client.close(), server.close())
 
 
-class WebSocketTest(unittest.TestCase):
+class WebSocketTest(BaseTestCase):
     local_address = sipmessage.Address(
         name="Alice",
         uri=sipmessage.URI(
@@ -277,5 +294,7 @@ class WebSocketTest(unittest.TestCase):
             local_address=self.local_address,
             remote_address=self.remote_address,
         )
+        self.assertNoDialogs(client)
+        self.assertNoDialogs(server)
 
         await asyncio.gather(client.close(), server.close())


### PR DESCRIPTION
In order to return to a clean state and allow memory to be reclaimed we need to unregister the dialog from the dialog layer.