### PR TITLE
Allow using `aiortc` version 1.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.5.5"
 
 # Dependencies
 dependencies = [
-    "aiortc >= 1.13, < 1.15",
+    "aiortc >= 1.13, < 1.16",
     "sipmessage >= 0.7.0, < 0.8.0",
     "websockets >= 15, < 16",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 # Version
 name = "sipua"
-version = "0.5.5"
+version = "0.5.6"
 
 # Dependencies
 dependencies = [


### PR DESCRIPTION
This in turn allows `av` version 17, which fixes some memory leaks.