### PR TITLE
Allow using `websockets` version 16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.5.6"
 dependencies = [
     "aiortc >= 1.13, < 1.16",
     "sipmessage >= 0.7.0, < 0.8.0",
-    "websockets >= 15, < 16",
+    "websockets >= 15, < 17",
 ]
 requires-python = ">= 3.10"
 


### PR DESCRIPTION
There are no breaking changes which affect us.